### PR TITLE
Update readme.md

### DIFF
--- a/challenges/Windows/users_everywhere/readme.md
+++ b/challenges/Windows/users_everywhere/readme.md
@@ -6,7 +6,7 @@ Submit the contents of the file at the root of all the zip files
 **NOTE:  Be sure to submit the flag in the correct format ( acsc18{flag} )**
 
 ## Flag
-acsc18{973}
+acsc18{977}
 
 ## Category
 Forensics
@@ -22,7 +22,7 @@ The PowerShell way
 ```powershell
 (get-aduser -Filter *).count
 ```
-1. Flag still needs to be submitted correctly as acsc18{973}
+1. Flag still needs to be submitted correctly as acsc18{977}
 
 ## Resources Required
 * PowerShell (or some langauge)


### PR DESCRIPTION
Domain Controller is now pied-piper.com

Count is 977 not 973

modified and corrected ad_build.ps1 spelling and logic errors

Changed: DC=Sandbox,DC=local to DC=pied-piper,DC=com 

savannah was misspelled; corrected

Portland and Seattle dsadd user command OU's were incorrectly pointing to East_Coast versus West_Coast


